### PR TITLE
fix Dockerfile to use ceph 12.2 base image

### DIFF
--- a/deploy/cephfs/docker/Dockerfile
+++ b/deploy/cephfs/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ceph/ceph:v14.2
+FROM ceph/ceph:v12.2
 LABEL maintainers="Ceph-CSI Authors"
 LABEL description="Ceph-CSI Plugin"
 

--- a/deploy/rbd/docker/Dockerfile
+++ b/deploy/rbd/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ceph/ceph:v14.2
+FROM ceph/ceph:v12.2
 LABEL maintainers="Ceph-CSI Authors"
 LABEL description="Ceph-CSI Plugin"
 


### PR DESCRIPTION
由于我们现在私有云交付的 ceph 集群版本都是 12.2 的，所以如果 rbd/cephfs plugin 插件依赖的 baseImage 是 ceph/ceph14.2 的话，会导致访问 ceph 集群时，客户端和服务端版本不一致，有潜在的不兼容风险。

所以这个 pr 将，rbd，cephfs plugin 的基础镜像修改为 12.2 版本的 ceph 镜像