### PR TITLE
delete cephfs quota setting logic, since 12.2 does not support

### DIFF
--- a/pkg/cephfs/volume.go
+++ b/pkg/cephfs/volume.go
@@ -70,11 +70,11 @@ func createVolume(volOptions *volumeOptions, adminCr *credentials, volID volumeI
 		return err
 	}
 
-	if bytesQuota > 0 {
-		if err := setVolumeAttribute(volRootCreating, "ceph.quota.max_bytes", fmt.Sprintf("%d", bytesQuota)); err != nil {
-			return err
-		}
-	}
+	// if bytesQuota > 0 {
+	// 	if err := setVolumeAttribute(volRootCreating, "ceph.quota.max_bytes", fmt.Sprintf("%d", bytesQuota)); err != nil {
+	// 		return err
+	// 	}
+	// }
 
 	if err := setVolumeAttribute(volRootCreating, "ceph.dir.layout.pool", volOptions.Pool); err != nil {
 		return fmt.Errorf("%v\ncephfs: Does pool '%s' exist?", err, volOptions.Pool)


### PR DESCRIPTION
由于 ceph 12.2 版本尚不支持对 cephfs 的存储设置 quota，想要支持 quota 至少需要 mimic 版本(13.2)
所以我们需要将代码中有关设置 cephfs quota 的部分隐藏
